### PR TITLE
Controller remapping support

### DIFF
--- a/include/PR/os_cont.h
+++ b/include/PR/os_cont.h
@@ -67,6 +67,33 @@ typedef struct {
 } OSContPad;
 
 typedef struct {
+    struct {
+        u16 l_jpad;
+        u16 r_jpad;
+        u16 d_jpad;
+        u16 u_jpad;
+        u16 z_trig;
+        u16 r_trig;
+        u16 l_trig;
+        u16 a_button;
+        u16 b_button;
+        u16 x_button;
+        u16 y_button;
+        u16 start_button;
+        u16 get_origin;
+        u16 use_origin;
+    } buttonMap;
+
+    u8 cStickDeadzone;
+    struct {
+        u16 left;
+        u16 right;
+        u16 down;
+        u16 up;
+    } cStickMap;
+} OSContButtonMap;
+
+typedef struct {
     void* address;     /* Ram pad Address:  11 bits */
     u8 databuffer[32]; /* address of the data buffer */
     u8 addressCrc;     /* CRC code for address */

--- a/include/PR/os_cont.h
+++ b/include/PR/os_cont.h
@@ -59,19 +59,12 @@ typedef struct {
     u16 button;
     s8 stick_x; /* -80 <= stick_x <= 80 */
     s8 stick_y; /* -80 <= stick_y <= 80 */
-    u8 errno;
-} OSContPad;
-
-typedef struct {
-    u16 button;
-    s8 stick_x; /* -80 <= stick_x <= 80 */
-    s8 stick_y; /* -80 <= stick_y <= 80 */
     s8 c_stick_x;
     s8 c_stick_y;
     u8 l_trig;
     u8 r_trig;
     u8 errno;
-} OSContPadEx;
+} OSContPad;
 
 typedef struct {
     void* address;     /* Ram pad Address:  11 bits */

--- a/include/PR/os_cont.h
+++ b/include/PR/os_cont.h
@@ -63,6 +63,17 @@ typedef struct {
 } OSContPad;
 
 typedef struct {
+	u16     button;
+	s8      stick_x;		/* -80 <= stick_x <= 80 */
+	s8      stick_y;		/* -80 <= stick_y <= 80 */
+	s8      c_stick_x;
+	s8      c_stick_y;
+	u8      l_trig;
+	u8      r_trig;
+	u8	errno;
+} OSContPadEx;
+
+typedef struct {
     void* address;     /* Ram pad Address:  11 bits */
     u8 databuffer[32]; /* address of the data buffer */
     u8 addressCrc;     /* CRC code for address */
@@ -102,6 +113,7 @@ typedef struct {
 #define CONT_ABSOLUTE    0x0001
 #define CONT_RELATIVE    0x0002
 #define CONT_JOYPORT     0x0004
+#define CONT_GCN         0x0008
 #define CONT_EEPROM      0x8000
 #define CONT_EEP16K      0x4000
 #define CONT_TYPE_MASK   0x1f07
@@ -149,6 +161,25 @@ typedef struct {
 #define L_CBUTTONS   CONT_C
 #define R_CBUTTONS   CONT_F
 #define D_CBUTTONS   CONT_D
+#define GCN_X_BUTTON 0x0040
+#define GCN_Y_BUTTON 0x0080
+
+/* Gamecube controller buttons */
+
+#define CONT_GCN_GET_ORIGIN  0x2000
+#define CONT_GCN_START       0x1000
+#define CONT_GCN_Y           0x0800
+#define CONT_GCN_X           0x0400
+#define CONT_GCN_B           0x0200
+#define CONT_GCN_A           0x0100
+#define CONT_GCN_USE_ORIGIN  0x0080
+#define CONT_GCN_L           0x0040
+#define CONT_GCN_R           0x0020
+#define CONT_GCN_Z           0x0010
+#define CONT_GCN_UP          0x0008
+#define CONT_GCN_DOWN        0x0004
+#define CONT_GCN_RIGHT       0x0002
+#define CONT_GCN_LEFT        0x0001
 
 /* Controller error number */
 
@@ -160,6 +191,9 @@ typedef struct {
 #define CONT_ERR_VOICE_MEMORY      13
 #define CONT_ERR_VOICE_WORD        14
 #define CONT_ERR_VOICE_NO_RESPONSE 15
+
+#define CONT_TYPE_N64 0
+#define CONT_TYPE_GCN 1
 
 #if defined(_LANGUAGE_C) || defined(_LANGUAGE_C_PLUS_PLUS)
 

--- a/include/PR/os_cont.h
+++ b/include/PR/os_cont.h
@@ -63,14 +63,14 @@ typedef struct {
 } OSContPad;
 
 typedef struct {
-	u16     button;
-	s8      stick_x;		/* -80 <= stick_x <= 80 */
-	s8      stick_y;		/* -80 <= stick_y <= 80 */
-	s8      c_stick_x;
-	s8      c_stick_y;
-	u8      l_trig;
-	u8      r_trig;
-	u8	errno;
+    u16 button;
+    s8 stick_x; /* -80 <= stick_x <= 80 */
+    s8 stick_y; /* -80 <= stick_y <= 80 */
+    s8 c_stick_x;
+    s8 c_stick_y;
+    u8 l_trig;
+    u8 r_trig;
+    u8 errno;
 } OSContPadEx;
 
 typedef struct {
@@ -166,20 +166,20 @@ typedef struct {
 
 /* Gamecube controller buttons */
 
-#define CONT_GCN_GET_ORIGIN  0x2000
-#define CONT_GCN_START       0x1000
-#define CONT_GCN_Y           0x0800
-#define CONT_GCN_X           0x0400
-#define CONT_GCN_B           0x0200
-#define CONT_GCN_A           0x0100
-#define CONT_GCN_USE_ORIGIN  0x0080
-#define CONT_GCN_L           0x0040
-#define CONT_GCN_R           0x0020
-#define CONT_GCN_Z           0x0010
-#define CONT_GCN_UP          0x0008
-#define CONT_GCN_DOWN        0x0004
-#define CONT_GCN_RIGHT       0x0002
-#define CONT_GCN_LEFT        0x0001
+#define CONT_GCN_GET_ORIGIN 0x2000
+#define CONT_GCN_START      0x1000
+#define CONT_GCN_Y          0x0800
+#define CONT_GCN_X          0x0400
+#define CONT_GCN_B          0x0200
+#define CONT_GCN_A          0x0100
+#define CONT_GCN_USE_ORIGIN 0x0080
+#define CONT_GCN_L          0x0040
+#define CONT_GCN_R          0x0020
+#define CONT_GCN_Z          0x0010
+#define CONT_GCN_UP         0x0008
+#define CONT_GCN_DOWN       0x0004
+#define CONT_GCN_RIGHT      0x0002
+#define CONT_GCN_LEFT       0x0001
 
 /* Controller error number */
 

--- a/include/PRinternal/controller.h
+++ b/include/PRinternal/controller.h
@@ -98,8 +98,7 @@ typedef struct {
     /* 0x4 */ u8 data[EEPROM_BLOCK_SIZE];
 } __OSContEepromFormat;
 
-typedef struct
-{
+typedef struct {
     /* 0x0 */ u8 dummy;
     /* 0x1 */ u8 txsize;
     /* 0x2 */ u8 rxsize;

--- a/include/PRinternal/controller.h
+++ b/include/PRinternal/controller.h
@@ -98,6 +98,23 @@ typedef struct {
     /* 0x4 */ u8 data[EEPROM_BLOCK_SIZE];
 } __OSContEepromFormat;
 
+typedef struct
+{
+    /* 0x0 */ u8 dummy;
+    /* 0x1 */ u8 txsize;
+    /* 0x2 */ u8 rxsize;
+    /* 0x3 */ u8 cmd;
+    /* 0x4 */ u8 analog_mode;
+    /* 0x5 */ u8 rumble;
+    /* 0x6 */ u16 button;
+    /* 0x8 */ u8 stick_x;
+    /* 0x9 */ u8 stick_y;
+    /* 0xA */ u8 c_stick_x;
+    /* 0xB */ u8 c_stick_y;
+    /* 0xC */ u8 l_trig;
+    /* 0xD */ u8 r_trig;
+} __OSContGCNShortPollFormat;
+
 // Joybus commands
 // from: http://en64.shoutwiki.com/wiki/SI_Registers_Detailed#CONT_CMD_Usage
 #define CONT_CMD_REQUEST_STATUS 0
@@ -113,6 +130,7 @@ typedef struct {
 #define CONT_CMD_SWRITE_VOICE   13
 #define CONT_CMD_CHANNEL_RESET  0xFD
 #define CONT_CMD_RESET          0xFF
+#define CONT_CMD_GCN_SHORTPOLL  0x40
 
 // Bytes transmitted for each joybus command
 #define CONT_CMD_REQUEST_STATUS_TX 1
@@ -127,6 +145,7 @@ typedef struct {
 #define CONT_CMD_WRITE4_VOICE_TX   7
 #define CONT_CMD_SWRITE_VOICE_TX   3
 #define CONT_CMD_RESET_TX          1
+#define CONT_CMD_GCN_SHORTPOLL_TX  3
 
 // Bytes received for each joybus command
 #define CONT_CMD_REQUEST_STATUS_RX 3
@@ -141,6 +160,7 @@ typedef struct {
 #define CONT_CMD_WRITE4_VOICE_RX   1
 #define CONT_CMD_SWRITE_VOICE_RX   1
 #define CONT_CMD_RESET_RX          3
+#define CONT_CMD_GCN_SHORTPOLL_RX  8
 
 #define CONT_CMD_NOP 0xff
 #define CONT_CMD_END 0xfe // indicates end of a command
@@ -215,6 +235,8 @@ extern OSPifRam __osEepPifRam;
 extern OSPifRam __osContPifRam;
 extern OSPifRam __osPfsPifRam;
 extern u8 __osMaxControllers;
+extern u8 __osControllerTypes[MAXCONTROLLERS];
+extern u8 __osGamecubeRumbleEnabled[MAXCONTROLLERS];
 
 // some version of this almost certainly existed since there's plenty of times where it's used right
 // before a return 0

--- a/src/io/contreaddata.c
+++ b/src/io/contreaddata.c
@@ -7,7 +7,7 @@ static void __osPackReadData(void);
 static u16 __osTranslateGCNButtons(u16, s32, s32);
 static u16 __osTranslateN64Buttons(u16);
 
-OSContButtonMap __osDefaultControllerMap = {
+static OSContButtonMap __osDefaultControllerMap = {
     .buttonMap = {
         .l_jpad = L_JPAD,
         .r_jpad = R_JPAD,
@@ -33,7 +33,7 @@ OSContButtonMap __osDefaultControllerMap = {
     },
 };
 
-OSContButtonMap *__osContCurButtonMap = &__osDefaultControllerMap;
+static OSContButtonMap *__osContCurButtonMap = &__osDefaultControllerMap;
 
 s32 osContStartReadData(OSMesgQueue* mq) {
     s32 ret = 0;
@@ -138,7 +138,7 @@ static void __osPackReadData(void) {
     *ptr = CONT_CMD_END;
 }
 
-void osContSetGCNMapping(OSContButtonMap* contMap) {
+void osContSetControllerMap(OSContButtonMap* contMap) {
     __osContCurButtonMap = contMap;
 }
 

--- a/src/io/contreaddata.c
+++ b/src/io/contreaddata.c
@@ -34,36 +34,6 @@ void osContGetReadData(OSContPad* data) {
 
     for (i = 0; i < __osMaxControllers; i++, data++) {
         if (__osControllerTypes[i] == CONT_TYPE_GCN) {
-            readformatgcn = *(__OSContGCNShortPollFormat*)ptr;
-            data->stick_x = ((s32)readformatgcn.stick_x) - 128;
-            data->stick_y = ((s32)readformatgcn.stick_y) - 128;
-            data->button =
-                __osTranslateGCNButtons(readformatgcn.button, readformatgcn.c_stick_x, readformatgcn.c_stick_y);
-            ptr += sizeof(__OSContGCNShortPollFormat);
-        } else {
-            readformat = *(__OSContReadFormat*)ptr;
-            data->errno = CHNL_ERR(readformat);
-
-            if (data->errno != 0) {
-                continue;
-            }
-
-            data->button = readformat.button;
-            data->stick_x = readformat.stick_x;
-            data->stick_y = readformat.stick_y;
-            ptr += sizeof(__OSContReadFormat);
-        }
-    }
-}
-
-void osContGetReadDataEx(OSContPadEx* data) {
-    u8* ptr = (u8*)__osContPifRam.ramarray;
-    __OSContReadFormat readformat;
-    __OSContGCNShortPollFormat readformatgcn;
-    int i;
-
-    for (i = 0; i < __osMaxControllers; i++, data++) {
-        if (__osControllerTypes[i] == CONT_TYPE_GCN) {
             s32 stick_x, stick_y, c_stick_x, c_stick_y;
             readformatgcn = *(__OSContGCNShortPollFormat*)ptr;
             stick_x = ((s32)readformatgcn.stick_x) - 128;

--- a/src/io/contreaddata.c
+++ b/src/io/contreaddata.c
@@ -37,12 +37,13 @@ void osContGetReadData(OSContPad* data) {
             readformatgcn = *(__OSContGCNShortPollFormat*)ptr;
             data->stick_x = ((s32)readformatgcn.stick_x) - 128;
             data->stick_y = ((s32)readformatgcn.stick_y) - 128;
-            data->button = __osTranslateGCNButtons(readformatgcn.button, readformatgcn.c_stick_x, readformatgcn.c_stick_y);
+            data->button =
+                __osTranslateGCNButtons(readformatgcn.button, readformatgcn.c_stick_x, readformatgcn.c_stick_y);
             ptr += sizeof(__OSContGCNShortPollFormat);
         } else {
             readformat = *(__OSContReadFormat*)ptr;
             data->errno = CHNL_ERR(readformat);
-            
+
             if (data->errno != 0) {
                 continue;
             }
@@ -80,7 +81,7 @@ void osContGetReadDataEx(OSContPadEx* data) {
         } else {
             readformat = *(__OSContReadFormat*)ptr;
             data->errno = CHNL_ERR(readformat);
-            
+
             if (data->errno != 0) {
                 continue;
             }
@@ -201,4 +202,3 @@ static u16 __osTranslateGCNButtons(u16 input, s32 c_stick_x, s32 c_stick_y) {
 
     return ret;
 }
-

--- a/src/io/contreaddata.c
+++ b/src/io/contreaddata.c
@@ -33,7 +33,7 @@ static OSContButtonMap __osDefaultControllerMap = {
     },
 };
 
-static OSContButtonMap *__osContCurButtonMap = &__osDefaultControllerMap;
+static OSContButtonMap* __osContCurButtonMap = &__osDefaultControllerMap;
 
 s32 osContStartReadData(OSMesgQueue* mq) {
     s32 ret = 0;
@@ -259,4 +259,3 @@ static u16 __osTranslateN64Buttons(u16 input) {
 
     return ret;
 }
-

--- a/src/io/contreaddata.c
+++ b/src/io/contreaddata.c
@@ -3,7 +3,10 @@
 #include "PRinternal/controller.h"
 #include "PRinternal/siint.h"
 
+#define GCN_C_STICK_THRESHOLD 38
+
 static void __osPackReadData(void);
+static u16 __osTranslateGCNButtons(u16, s32, s32);
 
 s32 osContStartReadData(OSMesgQueue* mq) {
     s32 ret = 0;
@@ -26,25 +29,78 @@ s32 osContStartReadData(OSMesgQueue* mq) {
 void osContGetReadData(OSContPad* data) {
     u8* ptr = (u8*)__osContPifRam.ramarray;
     __OSContReadFormat readformat;
+    __OSContGCNShortPollFormat readformatgcn;
     int i;
 
-    for (i = 0; i < __osMaxControllers; i++, ptr += sizeof(__OSContReadFormat), data++) {
-        readformat = *(__OSContReadFormat*)ptr;
-        data->errno = CHNL_ERR(readformat);
+    for (i = 0; i < __osMaxControllers; i++, data++) {
+        if (__osControllerTypes[i] == CONT_TYPE_GCN) {
+            readformatgcn = *(__OSContGCNShortPollFormat*)ptr;
+            data->stick_x = ((s32)readformatgcn.stick_x) - 128;
+            data->stick_y = ((s32)readformatgcn.stick_y) - 128;
+            data->button = __osTranslateGCNButtons(readformatgcn.button, readformatgcn.c_stick_x, readformatgcn.c_stick_y);
+            ptr += sizeof(__OSContGCNShortPollFormat);
+        } else {
+            readformat = *(__OSContReadFormat*)ptr;
+            data->errno = CHNL_ERR(readformat);
+            
+            if (data->errno != 0) {
+                continue;
+            }
 
-        if (data->errno != 0) {
-            continue;
+            data->button = readformat.button;
+            data->stick_x = readformat.stick_x;
+            data->stick_y = readformat.stick_y;
+            ptr += sizeof(__OSContReadFormat);
         }
+    }
+}
 
-        data->button = readformat.button;
-        data->stick_x = readformat.stick_x;
-        data->stick_y = readformat.stick_y;
+void osContGetReadDataEx(OSContPadEx* data) {
+    u8* ptr = (u8*)__osContPifRam.ramarray;
+    __OSContReadFormat readformat;
+    __OSContGCNShortPollFormat readformatgcn;
+    int i;
+
+    for (i = 0; i < __osMaxControllers; i++, data++) {
+        if (__osControllerTypes[i] == CONT_TYPE_GCN) {
+            s32 stick_x, stick_y, c_stick_x, c_stick_y;
+            readformatgcn = *(__OSContGCNShortPollFormat*)ptr;
+            stick_x = ((s32)readformatgcn.stick_x) - 128;
+            stick_y = ((s32)readformatgcn.stick_y) - 128;
+            data->stick_x = stick_x;
+            data->stick_y = stick_y;
+            c_stick_x = ((s32)readformatgcn.c_stick_x) - 128;
+            c_stick_y = ((s32)readformatgcn.c_stick_y) - 128;
+            data->c_stick_x = c_stick_x;
+            data->c_stick_y = c_stick_y;
+            data->button = __osTranslateGCNButtons(readformatgcn.button, c_stick_x, c_stick_y);
+            data->l_trig = readformatgcn.l_trig;
+            data->r_trig = readformatgcn.r_trig;
+            ptr += sizeof(__OSContGCNShortPollFormat);
+        } else {
+            readformat = *(__OSContReadFormat*)ptr;
+            data->errno = CHNL_ERR(readformat);
+            
+            if (data->errno != 0) {
+                continue;
+            }
+
+            data->button = readformat.button;
+            data->stick_x = readformat.stick_x;
+            data->stick_y = readformat.stick_y;
+            data->c_stick_x = 0;
+            data->c_stick_y = 0;
+            data->l_trig = 0;
+            data->r_trig = 0;
+            ptr += sizeof(__OSContReadFormat);
+        }
     }
 }
 
 static void __osPackReadData(void) {
     u8* ptr = (u8*)__osContPifRam.ramarray;
     __OSContReadFormat readformat;
+    __OSContGCNShortPollFormat readformatgcn;
     int i;
 
     for (i = 0; i < ARRLEN(__osContPifRam.ramarray); i++) {
@@ -60,10 +116,89 @@ static void __osPackReadData(void) {
     readformat.stick_x = -1;
     readformat.stick_y = -1;
 
+    readformatgcn.dummy = CONT_CMD_NOP;
+    readformatgcn.txsize = CONT_CMD_GCN_SHORTPOLL_TX;
+    readformatgcn.rxsize = CONT_CMD_GCN_SHORTPOLL_RX;
+    readformatgcn.cmd = CONT_CMD_GCN_SHORTPOLL;
+    readformatgcn.analog_mode = 3;
+    readformatgcn.rumble = 0;
+    readformatgcn.button = 0xFFFF;
+    readformatgcn.stick_x = -1;
+    readformatgcn.stick_y = -1;
+
     for (i = 0; i < __osMaxControllers; i++) {
-        *(__OSContReadFormat*)ptr = readformat;
-        ptr += sizeof(__OSContReadFormat);
+        if (__osControllerTypes[i] == CONT_TYPE_GCN) {
+            readformatgcn.rumble = __osGamecubeRumbleEnabled[i];
+            *(__OSContGCNShortPollFormat*)ptr = readformatgcn;
+            ptr += sizeof(__OSContGCNShortPollFormat);
+        } else {
+            *(__OSContReadFormat*)ptr = readformat;
+            ptr += sizeof(__OSContReadFormat);
+        }
     }
 
     *ptr = CONT_CMD_END;
 }
+
+static u16 __osTranslateGCNButtons(u16 input, s32 c_stick_x, s32 c_stick_y) {
+    u16 ret = 0;
+
+    // Face buttons
+    if (input & CONT_GCN_A) {
+        ret |= A_BUTTON;
+    }
+    if (input & CONT_GCN_B) {
+        ret |= B_BUTTON;
+    }
+    if (input & CONT_GCN_START) {
+        ret |= START_BUTTON;
+    }
+    if (input & CONT_GCN_X) {
+        ret |= GCN_X_BUTTON;
+    }
+    if (input & CONT_GCN_Y) {
+        ret |= GCN_Y_BUTTON;
+    }
+
+    // Triggers & Z
+    if (input & CONT_GCN_Z) {
+        ret |= Z_TRIG;
+    }
+    if (input & CONT_GCN_R) {
+        ret |= R_TRIG;
+    }
+    if (input & CONT_GCN_L) {
+        ret |= L_TRIG;
+    }
+
+    // D-Pad
+    if (input & CONT_GCN_UP) {
+        ret |= U_JPAD;
+    }
+    if (input & CONT_GCN_DOWN) {
+        ret |= D_JPAD;
+    }
+    if (input & CONT_GCN_LEFT) {
+        ret |= L_JPAD;
+    }
+    if (input & CONT_GCN_RIGHT) {
+        ret |= R_JPAD;
+    }
+
+    // C-stick to C-buttons
+    if (c_stick_x > GCN_C_STICK_THRESHOLD) {
+        ret |= R_CBUTTONS;
+    }
+    if (c_stick_x < -GCN_C_STICK_THRESHOLD) {
+        ret |= L_CBUTTONS;
+    }
+    if (c_stick_y > GCN_C_STICK_THRESHOLD) {
+        ret |= U_CBUTTONS;
+    }
+    if (c_stick_y < -GCN_C_STICK_THRESHOLD) {
+        ret |= D_CBUTTONS;
+    }
+
+    return ret;
+}
+

--- a/src/io/controller.c
+++ b/src/io/controller.c
@@ -6,6 +6,8 @@
 OSPifRam __osContPifRam;
 u8 __osContLastCmd;
 u8 __osMaxControllers;
+u8 __osControllerTypes[MAXCONTROLLERS];
+u8 __osGamecubeRumbleEnabled[MAXCONTROLLERS];
 
 OSTimer __osEepromTimer;
 OSMesgQueue __osEepromTimerQ ALIGNED(0x8);
@@ -67,6 +69,13 @@ void __osContGetInitData(u8* pattern, OSContStatus* data) {
         }
 
         data->type = requestHeader.typel << 8 | requestHeader.typeh;
+
+        if (data->type & CONT_GCN) {
+            __osControllerTypes[i] = CONT_TYPE_GCN;
+        } else {
+            __osControllerTypes[i] = CONT_TYPE_N64;
+        }
+
         data->status = requestHeader.status;
         bits |= 1 << i;
     }

--- a/src/io/motor.c
+++ b/src/io/motor.c
@@ -10,41 +10,45 @@ static OSPifRam __MotorDataBuf[MAXCONTROLLERS];
 
 s32 __osMotorAccess(OSPfs* pfs, s32 flag) {
     int i;
-    s32 ret;
+    s32 ret = 0;
     u8* ptr = (u8*)&__MotorDataBuf[pfs->channel];
 
     if (!(pfs->status & PFS_MOTOR_INITIALIZED)) {
         return 5;
     }
 
-    __osSiGetAccess();
-    __MotorDataBuf[pfs->channel].pifstatus = CONT_CMD_EXE;
-    ptr += pfs->channel;
+    if (__osControllerTypes[pfs->channel] == CONT_TYPE_GCN) {
+        __osGamecubeRumbleEnabled[pfs->channel] = flag;
+        __osContLastCmd = CONT_CMD_END;
+    } else {
+        __osSiGetAccess();
+        __MotorDataBuf[pfs->channel].pifstatus = CONT_CMD_EXE;
+        ptr += pfs->channel;
 
-    for (i = 0; i < BLOCKSIZE; i++) {
-        READFORMAT(ptr)->data[i] = flag;
-    }
+        for (i = 0; i < BLOCKSIZE; i++) {
+            READFORMAT(ptr)->data[i] = flag;
+        }
 
-    __osContLastCmd = CONT_CMD_END;
-    __osSiRawStartDma(OS_WRITE, &__MotorDataBuf[pfs->channel]);
-    osRecvMesg(pfs->queue, NULL, OS_MESG_BLOCK);
-    ret = __osSiRawStartDma(OS_READ, &__MotorDataBuf[pfs->channel]);
-    osRecvMesg(pfs->queue, NULL, OS_MESG_BLOCK);
+        __osContLastCmd = CONT_CMD_END;
+        __osSiRawStartDma(OS_WRITE, &__MotorDataBuf[pfs->channel]);
+        osRecvMesg(pfs->queue, NULL, OS_MESG_BLOCK);
+        ret = __osSiRawStartDma(OS_READ, &__MotorDataBuf[pfs->channel]);
+        osRecvMesg(pfs->queue, NULL, OS_MESG_BLOCK);
 
-    ret = READFORMAT(ptr)->rxsize & CHNL_ERR_MASK;
-    if (!ret) {
-        if (!flag) {
-            if (READFORMAT(ptr)->datacrc != 0) {
-                ret = PFS_ERR_CONTRFAIL;
-            }
-        } else {
-            if (READFORMAT(ptr)->datacrc != 0xEB) {
-                ret = PFS_ERR_CONTRFAIL;
+        ret = READFORMAT(ptr)->rxsize & CHNL_ERR_MASK;
+        if (!ret) {
+            if (!flag) {
+                if (READFORMAT(ptr)->datacrc != 0) {
+                    ret = PFS_ERR_CONTRFAIL;
+                }
+            } else {
+                if (READFORMAT(ptr)->datacrc != 0xEB) {
+                    ret = PFS_ERR_CONTRFAIL;
+                }
             }
         }
+        __osSiRelAccess();
     }
-
-    __osSiRelAccess();
 
     return ret;
 }
@@ -81,50 +85,52 @@ s32 osMotorInit(OSMesgQueue* mq, OSPfs* pfs, int channel) {
     pfs->activebank = 0xFF;
     pfs->status = 0;
 
-    ret = SELECT_BANK(pfs, 0xFE);
+    if (__osControllerTypes[pfs->channel] != CONT_TYPE_GCN) {
+        ret = SELECT_BANK(pfs, 0xFE);
 
-    if (ret == PFS_ERR_NEW_PACK) {
+        if (ret == PFS_ERR_NEW_PACK) {
+            ret = SELECT_BANK(pfs, 0x80);
+        }
+
+        if (ret != 0) {
+            return ret;
+        }
+
+        ret = __osContRamRead(mq, channel, CONT_BLOCK_DETECT, temp);
+
+        if (ret == PFS_ERR_NEW_PACK) {
+            ret = PFS_ERR_CONTRFAIL;
+        }
+
+        if (ret != 0) {
+            return ret;
+        } else if (temp[31] == 254) {
+            return PFS_ERR_DEVICE;
+        }
+
         ret = SELECT_BANK(pfs, 0x80);
-    }
+        if (ret == PFS_ERR_NEW_PACK) {
+            ret = PFS_ERR_CONTRFAIL;
+        }
 
-    if (ret != 0) {
-        return ret;
-    }
+        if (ret != 0) {
+            return ret;
+        }
 
-    ret = __osContRamRead(mq, channel, CONT_BLOCK_DETECT, temp);
+        ret = __osContRamRead(mq, channel, CONT_BLOCK_DETECT, temp);
+        if (ret == PFS_ERR_NEW_PACK) {
+            ret = PFS_ERR_CONTRFAIL;
+        }
 
-    if (ret == PFS_ERR_NEW_PACK) {
-        ret = PFS_ERR_CONTRFAIL;
-    }
+        if (ret != 0) {
+            return ret;
+        } else if (temp[31] != 0x80) {
+            return PFS_ERR_DEVICE;
+        }
 
-    if (ret != 0) {
-        return ret;
-    } else if (temp[31] == 254) {
-        return PFS_ERR_DEVICE;
-    }
-
-    ret = SELECT_BANK(pfs, 0x80);
-    if (ret == PFS_ERR_NEW_PACK) {
-        ret = PFS_ERR_CONTRFAIL;
-    }
-
-    if (ret != 0) {
-        return ret;
-    }
-
-    ret = __osContRamRead(mq, channel, CONT_BLOCK_DETECT, temp);
-    if (ret == PFS_ERR_NEW_PACK) {
-        ret = PFS_ERR_CONTRFAIL;
-    }
-
-    if (ret != 0) {
-        return ret;
-    } else if (temp[31] != 0x80) {
-        return PFS_ERR_DEVICE;
-    }
-
-    if (!(pfs->status & PFS_MOTOR_INITIALIZED)) {
-        __osMakeMotorData(channel, &__MotorDataBuf[channel]);
+        if (!(pfs->status & PFS_MOTOR_INITIALIZED)) {
+            __osMakeMotorData(channel, &__MotorDataBuf[channel]);
+        }
     }
 
     pfs->status = PFS_MOTOR_INITIALIZED;


### PR DESCRIPTION
Allows both N64 and GC controllers to be remapped. Default mapping should be transparent.

Might require performance testing on console.

Based on comments in #8