### PR TITLE
Fix CI typo that caused only libultra_rom to be built

### DIFF
--- a/.github/workflows/ci_gcc.yml
+++ b/.github/workflows/ci_gcc.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [libultra, libultra_d, libultra_rom]
+        target: [libultra, libultra_d, libultra_rom]
 
     steps:
     - name: Checkout repository
@@ -27,8 +27,8 @@ jobs:
     - name: Verify formatting on all files
       run: python3 tools/check_format.py --verbose
 
-    - name: Build ${{ matrix.version }}
-      run: make -j $(nproc) VERSION=${{ matrix.version }}
+    - name: Build ${{ matrix.target }}
+      run: make -j $(nproc) TARGET=${{ matrix.target }}
 
     - name: 'Upload Artifact'
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
I made a typo on the cleaned up CI with the wrong variable, all libultra versions should autobuild now